### PR TITLE
ci: migrate GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -31,16 +31,44 @@ jobs:
       - name: Run regression checks
         run: npm run regression
 
+      - name: Prepare artifact round-trip fixture
+        shell: bash
+        run: |
+          mkdir -p data/actions-node24-smoke
+          printf '%s\n' "Terma Actions Node 24 smoke: ${GITHUB_SHA}" > data/actions-node24-smoke/payload.txt
+          echo "TERMA_ACTIONS_SMOKE_SHA=$(sha256sum data/actions-node24-smoke/payload.txt | cut -d ' ' -f 1)" >> "$GITHUB_ENV"
+
+      - name: Upload artifact round-trip fixture
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: terma-actions-node24-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: error
+          retention-days: 1
+          path: data/actions-node24-smoke/payload.txt
+
+      - name: Download artifact round-trip fixture
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          digest-mismatch: error
+          name: terma-actions-node24-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+          path: data/actions-node24-roundtrip
+
+      - name: Verify artifact round-trip digest
+        shell: bash
+        run: |
+          test -f data/actions-node24-roundtrip/payload.txt
+          test "$(sha256sum data/actions-node24-roundtrip/payload.txt | cut -d ' ' -f 1)" = "$TERMA_ACTIONS_SMOKE_SHA"
+
   ui-smoke:
     name: Ubuntu / Electron UI smoke
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -62,9 +90,9 @@ jobs:
 
       - name: Upload UI diagnostics on failure
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ui-smoke-diagnostics
+          name: ui-smoke-diagnostics-${{ github.run_attempt }}
           if-no-files-found: ignore
           path: |
             data/ui-smoke-*.png
@@ -75,10 +103,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -101,10 +129,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -35,10 +35,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -56,9 +56,10 @@ jobs:
         run: node scripts/release-artifacts-check.js windows
 
       - name: Upload Windows workflow artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Terma-windows-x64
+          overwrite: true
           retention-days: 7
           path: |
             release/*.exe
@@ -70,10 +71,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -104,9 +105,10 @@ jobs:
         run: node scripts/release-artifacts-check.js linux
 
       - name: Upload Linux workflow artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Terma-linux-x64
+          overwrite: true
           retention-days: 7
           path: |
             release/*.AppImage
@@ -120,10 +122,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -168,9 +170,10 @@ jobs:
           done < <(find release -path "*/${PRODUCT_FILENAME}.app/Contents/Info.plist" -type f -print)
           test "$app_count" -eq 2
       - name: Upload macOS workflow artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Terma-macos-x64-arm64
+          overwrite: true
           retention-days: 7
           path: |
             release/*.dmg
@@ -183,10 +186,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -226,9 +229,10 @@ jobs:
           tar -tzf "$archive" | grep "^${PRODUCT_SLUG}/" > /dev/null
 
       - name: Upload Linux/source workflow artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Terma-linux-source-noarch
+          overwrite: true
           retention-days: 7
           path: release-source/*.tar.gz
 
@@ -245,17 +249,18 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
 
       - name: Download all platform artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          digest-mismatch: error
           pattern: Terma-*
           path: release-assets
           merge-multiple: true
@@ -290,7 +295,7 @@ jobs:
         run: node scripts/release-notes.js
 
       - name: Upload complete draft release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           draft: true
           fail_on_unmatched_files: true

--- a/scripts/release-publish-assets-check.js
+++ b/scripts/release-publish-assets-check.js
@@ -14,6 +14,7 @@ for (const token of [
   "publish-release:",
   "needs:",
   "actions/download-artifact@",
+  "digest-mismatch: error",
   "draft: true",
   "Verify uploaded release assets",
   "npm sbom",

--- a/scripts/workflow-action-pin-check.js
+++ b/scripts/workflow-action-pin-check.js
@@ -4,22 +4,37 @@ const path = require("node:path");
 
 const workflowDirectory = path.resolve(__dirname, "../.github/workflows");
 const findings = [];
+const node24Pins = new Map([
+  ["actions/checkout", "3d3c42e5aac5ba805825da76410c181273ba90b1"],
+  ["actions/setup-node", "820762786026740c76f36085b0efc47a31fe5020"],
+  ["actions/upload-artifact", "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"],
+  ["actions/download-artifact", "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"],
+  ["softprops/action-gh-release", "3d0d9888cb7fd7b750713d6e236d1fcb99157228"]
+]);
+const seenNode24Actions = new Set();
 for (const name of fs.readdirSync(workflowDirectory).filter(item => /\.ya?ml$/i.test(item))) {
   const lines = fs.readFileSync(path.join(workflowDirectory, name), "utf8").split(/\r?\n/);
   lines.forEach((line, index) => {
     const match = line.match(/^\s*uses:\s*([^\s#]+)(?:\s+#.*)?$/);
     if (!match) return;
-    const reference = match[1].split("@").at(-1) || "";
+    const [action, reference = ""] = match[1].split("@");
     if (!/^[0-9a-f]{40}$/i.test(reference)) findings.push(`${name}:${index + 1} ${match[1]}`);
+    const requiredPin = node24Pins.get(action);
+    if (requiredPin) {
+      seenNode24Actions.add(action);
+      if (reference !== requiredPin) findings.push(`${name}:${index + 1} ${action} must use Node 24 pin ${requiredPin}`);
+    }
   });
 }
 
 assert.deepEqual(findings, [], `GitHub Actions 必须固定到完整 commit SHA：\n${findings.join("\n")}`);
+assert.deepEqual([...seenNode24Actions].sort(), [...node24Pins.keys()].sort(), "Node 24 Actions 迁移缺少必要 action");
 const regressionWorkflow = fs.readFileSync(path.join(workflowDirectory, "regression.yml"), "utf8");
 assert.match(regressionWorkflow, /xvfb-run[^\n]*npm run ui:smoke/, "Regression workflow 必须在虚拟显示器中运行 Electron UI smoke");
 assert.match(regressionWorkflow, /TERMA_UI_NO_SANDBOX:\s*["']?1["']?/, "Linux CI 的 Electron UI smoke 必须显式关闭不可用的 SUID sandbox");
 assert.match(regressionWorkflow, /TERMA_UI_VISUAL_DIR:\s*data\/ui-visual-current/, "Electron UI smoke 必须把视觉诊断写入 artifact 目录");
 assert.match(regressionWorkflow, /name:\s*Windows \/ Node\.js 22[\s\S]*runs-on:\s*windows-latest/, "Regression workflow 缺少 Windows 轻量检查");
 assert.match(regressionWorkflow, /name:\s*macOS \/ Node\.js 22[\s\S]*runs-on:\s*macos-latest/, "Regression workflow 缺少 macOS 轻量检查");
+assert.match(regressionWorkflow, /name:\s*Upload artifact round-trip fixture[\s\S]*name:\s*Download artifact round-trip fixture[\s\S]*name:\s*Verify artifact round-trip digest/, "Regression workflow 缺少 artifact 上传、下载和摘要往返检查");
 assert.ok(fs.existsSync(path.resolve(__dirname, "../.github/dependabot.yml")), "仓库缺少 Dependabot 配置");
-console.log("GitHub Actions 引用检查通过：所有 workflow action 均固定到完整 commit SHA");
+console.log("GitHub Actions 引用检查通过：Node 24 action 均固定到已审核的完整 commit SHA，并覆盖 artifact 往返摘要校验");


### PR DESCRIPTION
## Summary

- migrate checkout, setup-node, upload-artifact, download-artifact, and release actions to audited Node.js 24 releases pinned by full commit SHA
- add an artifact upload/download round-trip with SHA-256 verification to pull request regression
- preserve release digest validation, rerun replacement controls, draft verification, SBOM, and SHA256SUMS gates

## Validation

- `npm run regression` (201 checks)
- `node scripts/workflow-action-pin-check.js`
- `node scripts/release-publish-assets-check.js`
- `git diff --check`